### PR TITLE
[WIP] Add log handler for writing errors to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 bin/*
+logs/*
 Dockerfile.cross
 
 # Test binary, built with `go test -c`

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,53 @@
+package logger
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Global logger
+// since we are running a TUI, we dont want to write to stdout,
+// so we will write to stderr + a log file
+var errorLogger *log.Logger
+
+func init() {
+	initLog()
+}
+
+// initLog creates a new log file with a timestamped name each run.
+func initLog() (*os.File, error) {
+	logDir := "logs"
+	err := os.MkdirAll(logDir, 0755)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create log directory: %w", err)
+	} else {
+		fmt.Printf("Log directory '%s' created or already exists\n", logDir)
+	}
+
+	timestamp := time.Now().Format("2006-01-02_15-04-05")
+	filename := filepath.Join(logDir, fmt.Sprintf("signalhound_%s.log", timestamp))
+
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open log file: %w", err)
+	} else {
+		fmt.Printf("Log file %s created\n", filename)
+	}
+
+	// Create a logger that writes to both file and stderr
+	errorLogger = log.New(file, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
+	return file, nil
+}
+
+// HandleError logs errors bot to stderr and also a log file
+func HandleError(err error) {
+	if err != nil {
+		// Print to stderr
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		// Log to file
+		errorLogger.Println(err)
+	}
+}


### PR DESCRIPTION
Fixes issue #6. On start will print the log file (timestamped):

<img width="514" height="90" alt="Screenshot 2025-10-17 at 5 26 15 PM" src="https://github.com/user-attachments/assets/b4114079-9b53-44c9-b8d5-28e1ebc36bfc" />

Since its a TUI we can't write to `stdout`, but can write to `stderr` and to a log file. Example:

```yaml
# /logs/signalhound_2025-10-17_17-10-38.log
ERROR: 2025/10/17 17:13:45 logger.go:54: Could not resolve to a node with the global id of 'PVT_kwDOAM_34M4AAThW'.
ERROR: 2025/10/17 17:14:02 logger.go:54: Could not resolve to a node with the global id of 'PVT_kwDOAM_34M4AAThW'.
ERROR: 2025/10/17 17:14:04 logger.go:54: Could not resolve to a node with the global id of 'PVT_kwDOAM_34M4AAThW'.
ERROR: 2025/10/17 17:14:07 logger.go:54: Could not resolve to a node with the global id of 'PVT_kwDOAM_34M4AAThW'.
ERROR: 2025/10/17 17:14:11 logger.go:54: Could not resolve to a node with the global id of 'PVT_kwDOAM_34M4AAThW'.
```
Purpose of this was to see if there was more to the specific error above than I could see in the TUI.  
