### PR TITLE
Add PAT instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ you create a PAT you will store it in the local `SIGNALHOUND_GITHUB_TOKEN` or `G
 so that signalhound can access it.  For instructions to create a GitHub PAT,
 [visit the docs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token).
 
+Currently a `classic` PAT with `project` and `repo` scopes is required.
+
 ```bash
 # Best practice is to use a fine-grained personal access token
 # specifically created for signalhound.

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -101,8 +101,9 @@ func (r *Repository) getWorkflow() (*g3.Workflow, error) {
 	return workflow, err
 }
 
-// CreateDraftIssue creates a new issue draft issue in the board with a
-// specific test issue template.
+// CreateDraftIssue creates a new draft issue in the GitHub project board with
+// specific field values set automatically. Requires a Classic PAT with 'repo'
+// and 'project' scopes.
 func (g *GitHub) CreateDraftIssue(title, body string) error {
 	var mutationDraft struct {
 		AddProjectV2DraftIssue struct {


### PR DESCRIPTION
Related to issue #9. 
Not sure if we want to call this a fix or if we want to instead ensure it supports a modern `granular token`.